### PR TITLE
fix: use proper version

### DIFF
--- a/moon.mod.json
+++ b/moon.mod.json
@@ -1,8 +1,8 @@
 {
     "name": "dijdzv/websys",
-    "version": "0.3.0",
+    "version": "0.3.1",
     "deps": {
-        "moonbitlang/async": "0.16"
+        "moonbitlang/async": "0.16.0"
     },
     "readme": "README.md",
     "repository": "https://github.com/dijdzv/websys.mbt",


### PR DESCRIPTION
The build system used to allow `VersionReq` instead of `Version` for the version resolution, but that was a buggy implementation. The latest version made that stricter. And this repo is the one that gets the impact. This PR fixes the version declaration for dependency.